### PR TITLE
Change Gpio state judgement method

### DIFF
--- a/blink/src/main/java/com/example/androidthings/simplepio/BlinkActivity.java
+++ b/blink/src/main/java/com/example/androidthings/simplepio/BlinkActivity.java
@@ -39,6 +39,7 @@ public class BlinkActivity extends Activity {
 
     private Handler mHandler = new Handler();
     private Gpio mLedGpio;
+    private static boolean mLedState = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -84,8 +85,14 @@ public class BlinkActivity extends Activity {
             }
             try {
                 // Toggle the GPIO state
-                mLedGpio.setValue(!mLedGpio.getValue());
-                Log.d(TAG, "State set to " + mLedGpio.getValue());
+                if (!BoardDefaults.isNxpBoard()) {
+                    mLedGpio.setValue(!mLedGpio.getValue());
+                    Log.d(TAG, "State set to " + mLedGpio.getValue());
+                } else {
+                    mLedGpio.setValue(mLedState);
+                    Log.d(TAG, "State set to " + mLedState);
+                    mLedState = !mLedState;
+                }
 
                 // Reschedule the same runnable in {#INTERVAL_BETWEEN_BLINKS_MS} milliseconds
                 mHandler.postDelayed(mBlinkRunnable, INTERVAL_BETWEEN_BLINKS_MS);

--- a/blink/src/main/java/com/example/androidthings/simplepio/BoardDefaults.java
+++ b/blink/src/main/java/com/example/androidthings/simplepio/BoardDefaults.java
@@ -50,6 +50,19 @@ public class BoardDefaults {
         }
     }
 
+    /**
+     * NXP's Board can't use the API Gpio.getValue if
+     * the gpio is used for output.
+     */
+    public static boolean isNxpBoard() {
+        switch (getBoardVariant()) {
+            case DEVICE_NXP:
+                return true;
+            default:
+                return false;
+        }
+    }
+
     private static String getBoardVariant() {
         if (!sBoardVariant.isEmpty()) {
             return sBoardVariant;


### PR DESCRIPTION
NXP's Board can't use the API Gpio.getValue,
if the gpio is used for output.

Signed-off-by: Jindong <jindong.yue@nxp.com>